### PR TITLE
Ensure we're submitting a supported signature algorithm

### DIFF
--- a/lib/net/ssh/authentication/methods/publickey.rb
+++ b/lib/net/ssh/authentication/methods/publickey.rb
@@ -97,7 +97,7 @@ module Net
               pubkey_algorithms.each do |pk_alg|
                 case pk_alg
                 when "rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"
-                  if session.transport.algorithms.supported_signature_algs.includes? ok_alg
+                  if session.transport.algorithms.supported_signature_algs.includes? pk_alg
                     if authenticate_with_alg(identity, next_service, username, type, pk_alg)
                       # success
                       return true

--- a/lib/net/ssh/authentication/methods/publickey.rb
+++ b/lib/net/ssh/authentication/methods/publickey.rb
@@ -97,7 +97,7 @@ module Net
               pubkey_algorithms.each do |pk_alg|
                 case pk_alg
                 when "rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"
-                  if session.transport.algorithms.supported_signature_algs.includes? pk_alg
+                  if session.transport.algorithms.supported_signature_algs.include? pk_alg
                     if authenticate_with_alg(identity, next_service, username, type, pk_alg)
                       # success
                       return true

--- a/lib/net/ssh/authentication/methods/publickey.rb
+++ b/lib/net/ssh/authentication/methods/publickey.rb
@@ -97,9 +97,11 @@ module Net
               pubkey_algorithms.each do |pk_alg|
                 case pk_alg
                 when "rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"
-                  if authenticate_with_alg(identity, next_service, username, pk_alg, pk_alg)
-                    # success
-                    return true
+                  if session.transport.algorithms.supported_signature_algs.includes? ok_alg
+                    if authenticate_with_alg(identity, next_service, username, type, pk_alg)
+                      # success
+                      return true
+                    end
                   end
                 end
               end

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -198,17 +198,6 @@ module Net
               packet.read_buffer
             end
           end
-
-          data[:kex]                = packet.read_string.split(/,/)
-          data[:host_key]           = packet.read_string.split(/,/)
-          data[:encryption_client]  = packet.read_string.split(/,/)
-          data[:encryption_server]  = packet.read_string.split(/,/)
-          data[:hmac_client]        = packet.read_string.split(/,/)
-          data[:hmac_server]        = packet.read_string.split(/,/)
-          data[:compression_client] = packet.read_string.split(/,/)
-          data[:compression_server] = packet.read_string.split(/,/)
-          data[:language_client]    = packet.read_string.split(/,/)
-          data[:language_server]    = packet.read_string.split(/,/)
         end
         # Called by the transport layer when a KEXINIT packet is received, indicating
         # that the server wants to exchange keys. This can be spontaneous, or it

--- a/lib/net/ssh/transport/constants.rb
+++ b/lib/net/ssh/transport/constants.rb
@@ -12,6 +12,7 @@ module Net
         DEBUG                     = 4
         SERVICE_REQUEST           = 5
         SERVICE_ACCEPT            = 6
+        EXT_INFO                  = 7
 
         #--
         # Algorithm negotiation messages

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -209,6 +209,9 @@ module Net
             when KEXINIT
               algorithms.accept_kexinit(packet)
 
+            when EXT_INFO
+              algorithms.accept_ext_info(packet)
+
             else
               return packet if algorithms.allow?(packet)
 


### PR DESCRIPTION
certain SSH servers ONLY support the legacy (now deprecated) `ssh-rsa` signature algorithm for RSA keys, and so vehemently don't support anything else that if we attempt it, they gracelessly disconnect us.

This PR adds support to detect the EXT_INFO packet and without it, we default to only use `ssh-rsa`. The spec is ambiguous about whether this is the correct behaviour. 